### PR TITLE
ci(security): use cargo-deny-action v2 for CVSS 4.0 compat

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install security tools
         run: |
           # Install tools with --locked for reproducible builds
-          cargo install cargo-audit cargo-deny cargo-outdated --locked
+          cargo install cargo-audit cargo-outdated --locked
 
       - name: Run cargo audit
         run: |
@@ -67,11 +67,7 @@ jobs:
 
       - name: Run cargo deny
         continue-on-error: true
-        run: |
-          # Clear advisory DB cache to force fresh fetch
-          rm -rf ~/.cargo/advisory-dbs 2>/dev/null || true
-          # Run cargo deny; continue even if advisory DB has issues
-          cargo deny check 2>&1 || echo "⚠️ cargo deny check completed with issues"
+        uses: EmbarkStudios/cargo-deny-action@v2
 
       - name: Check for outdated dependencies
         continue-on-error: true


### PR DESCRIPTION
## Summary
- Replace manual `cargo install cargo-deny` with `EmbarkStudios/cargo-deny-action@v2` in `security.yml`
- Fixes CVSS 4.0 advisory database parsing failures with older cargo-deny versions
- Aligns with `quality-consolidated.yml` which already uses the action

## Test plan
- [ ] CI security workflow completes without cargo-deny parse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Switch the security workflow to EmbarkStudios/cargo-deny-action@v2 and stop installing cargo-deny via cargo.