### PR TITLE
fix(release): replace dawidd6 action with direct Homebrew formula push

### DIFF
--- a/.github/workflows/release-consolidated.yml
+++ b/.github/workflows/release-consolidated.yml
@@ -223,11 +223,10 @@ jobs:
         env:
           VERSION: ${{ needs.validate.outputs.version }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          SHA_ARM: ${{ env.SHA_ARM }}
-          SHA_X86: ${{ env.SHA_X86 }}
-          SHA_LIN: ${{ env.SHA_LIN }}
+          # SHA_ARM, SHA_X86, SHA_LIN are set via GITHUB_ENV by the previous step
+          # and flow automatically into this step's shell environment.
         run: |
-          # Write the formula to a file to avoid quoting/escaping issues.
+          # Build the formula inline and push it to the tap via the GitHub Contents API.
           python3 - <<'PYEOF'
 import os, base64, json, urllib.request, urllib.error
 
@@ -265,7 +264,7 @@ class Batless < Formula
   end
 
   test do
-    assert_match "batless", shell_output("\#{bin}/batless --version")
+    assert_match "batless", shell_output("#{{bin}}/batless --version")
   end
 end
 """

--- a/.github/workflows/release-consolidated.yml
+++ b/.github/workflows/release-consolidated.yml
@@ -207,13 +207,92 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     timeout-minutes: 10
     steps:
-      - name: Update Homebrew formula
-        uses: dawidd6/action-homebrew-bump-formula@1446dca236b0440c6f02723a3f14f13be2c04ab0 # v7
-        with:
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          tap: docdyhr/homebrew-tap
-          formula: batless
-          tag: v${{ needs.validate.outputs.version }}
+      - name: Download release assets and compute SHA256s
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          BASE="https://github.com/docdyhr/batless/releases/download/v${VERSION}"
+          curl -fsSL "${BASE}/batless-aarch64-apple-darwin.tar.gz"    -o aarch64.tar.gz
+          curl -fsSL "${BASE}/batless-x86_64-apple-darwin.tar.gz"     -o x86_64.tar.gz
+          curl -fsSL "${BASE}/batless-x86_64-unknown-linux-gnu.tar.gz" -o linux.tar.gz
+          echo "SHA_ARM=$(sha256sum aarch64.tar.gz | cut -d' ' -f1)"   >> "$GITHUB_ENV"
+          echo "SHA_X86=$(sha256sum x86_64.tar.gz  | cut -d' ' -f1)"   >> "$GITHUB_ENV"
+          echo "SHA_LIN=$(sha256sum linux.tar.gz   | cut -d' ' -f1)"   >> "$GITHUB_ENV"
+
+      - name: Push updated formula to homebrew-tap
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          SHA_ARM: ${{ env.SHA_ARM }}
+          SHA_X86: ${{ env.SHA_X86 }}
+          SHA_LIN: ${{ env.SHA_LIN }}
+        run: |
+          # Write the formula to a file to avoid quoting/escaping issues.
+          python3 - <<'PYEOF'
+import os, base64, json, urllib.request, urllib.error
+
+version  = os.environ["VERSION"]
+sha_arm  = os.environ["SHA_ARM"]
+sha_x86  = os.environ["SHA_X86"]
+sha_lin  = os.environ["SHA_LIN"]
+token    = os.environ["HOMEBREW_TAP_TOKEN"]
+base_url = f"https://github.com/docdyhr/batless/releases/download/v{version}"
+
+formula = f"""\
+class Batless < Formula
+  desc "A non-blocking, LLM-friendly code viewer inspired by bat"
+  homepage "https://github.com/docdyhr/batless"
+  version "{version}"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "{base_url}/batless-aarch64-apple-darwin.tar.gz"
+      sha256 "{sha_arm}"
+    else
+      url "{base_url}/batless-x86_64-apple-darwin.tar.gz"
+      sha256 "{sha_x86}"
+    end
+  end
+
+  on_linux do
+    url "{base_url}/batless-x86_64-unknown-linux-gnu.tar.gz"
+    sha256 "{sha_lin}"
+  end
+
+  def install
+    bin.install "batless"
+  end
+
+  test do
+    assert_match "batless", shell_output("\#{bin}/batless --version")
+  end
+end
+"""
+
+api = "https://api.github.com/repos/docdyhr/homebrew-tap/contents/Formula/batless.rb"
+headers = {
+    "Authorization": f"Bearer {token}",
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+}
+
+# Fetch current file SHA (required by the GitHub Contents API for updates).
+req = urllib.request.Request(api, headers=headers)
+with urllib.request.urlopen(req) as resp:
+    file_sha = json.loads(resp.read())["sha"]
+
+# Push the new formula directly to main (no PR).
+payload = json.dumps({
+    "message": f"chore: update batless to v{version}",
+    "content": base64.b64encode(formula.encode()).decode(),
+    "sha": file_sha,
+}).encode()
+req = urllib.request.Request(api, data=payload, headers=headers, method="PUT")
+with urllib.request.urlopen(req) as resp:
+    commit_sha = json.loads(resp.read())["commit"]["sha"][:8]
+    print(f"Formula updated → commit {commit_sha}")
+PYEOF
 
   # Post-release monitoring
   monitor:


### PR DESCRIPTION
## Problem

The `dawidd6/action-homebrew-bump-formula` action was silently opening a PR in the tap repo instead of pushing directly, and the PR it created was **incomplete** — it updated the version and Linux SHA but left the macOS URLs and SHA256s at the previous version. This was discovered after the v0.6.0 release (manual fix applied to the tap).

## Solution

Replace the third-party action with a self-contained two-step script:

1. **Download + hash** — `curl` the three release tarballs (aarch64-apple-darwin, x86_64-apple-darwin, x86_64-unknown-linux-gnu) from the just-created GitHub release and compute SHA256s with `sha256sum`
2. **Push directly** — Python stdlib script builds the complete formula string and pushes it to `docdyhr/homebrew-tap` main via the GitHub Contents API (`PUT`) — no PR, no middleman, no third-party action

## Why Python instead of shell for the push step

The formula string contains double-quotes that would require layered escaping in shell. Python's f-strings sidestep this cleanly, and only stdlib is used (`os`, `base64`, `json`, `urllib`).

## Test plan
- [ ] CI passes on this PR
- [ ] Next release (`v0.6.1`+) automatically produces a correct formula with all three platform URLs and SHAs

## Summary by Sourcery

Enhancements:
- Replace the dawidd6 Homebrew bump-formula GitHub Action with an inline workflow that downloads release tarballs, computes SHA256 checksums, and updates the Homebrew formula via the GitHub Contents API.