### PR TITLE
fix(ci): tighten tag-after-merge condition to avoid false triggers

### DIFF
--- a/.github/workflows/release-consolidated.yml
+++ b/.github/workflows/release-consolidated.yml
@@ -270,7 +270,7 @@ jobs:
   tag-after-merge:
     name: Tag After Release PR
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.title, 'release')
+    if: github.event.pull_request.merged == true && (startsWith(github.event.pull_request.title, 'release ') || startsWith(github.event.pull_request.title, 'chore(release)'))
     permissions:
       contents: write
     timeout-minutes: 5


### PR DESCRIPTION
## Summary

- `contains(title, 'release')` matched any PR title containing the word "release" (e.g. *"fix ... in **release** workflow"*), causing `tag-after-merge` to fire and fail on every non-release PR
- Changed to `startsWith` checks so the job only runs on actual release PRs titled `release X.Y.Z` or `chore(release)...`

## Test plan

- [ ] CI passes
- [ ] A future non-release PR whose title contains "release" will no longer trigger `tag-after-merge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Restrict the tag-after-merge job in the consolidated release workflow to PR titles starting with "release " or "chore(release)" to prevent false triggers on non-release PRs.