### PR TITLE
fix(scorecard): pin npm/pip deps and switch markdownlint to SHA-pinned action

### DIFF
--- a/.github/scripts/pipeline-health-check.sh
+++ b/.github/scripts/pipeline-health-check.sh
@@ -136,13 +136,12 @@ fix_dependencies() {
     # For Node.js projects
     if [ -f "package.json" ]; then
         if [ -f "package-lock.json" ]; then
-            # Reproducible install from lockfile (Scorecard: no unpinned installs)
+            # Reproducible install from lockfile (integrity hashes in lockfile satisfy Scorecard)
             npm ci
-            npm audit --audit-level=high  # report without auto-fixing (review manually)
+            npm audit --audit-level=high
         else
-            # No lockfile present — generate one, then audit
-            npm install --ignore-scripts
-            npm audit fix --ignore-scripts
+            log "⚠️  No package-lock.json found — run 'npm install' locally and commit the lockfile" "$YELLOW"
+            log "   Skipping npm dependency check (lockfile required for reproducible installs)" "$YELLOW"
         fi
     fi
 
@@ -202,21 +201,13 @@ check_precommit() {
 
     if ! command -v pre-commit &> /dev/null; then
         log "Installing pre-commit..." "$YELLOW"
-        # Download wheel, verify hash, then install (avoids --require-hashes needing
-        # hashes for all transitive deps while still ensuring the main package integrity)
-        _PC_WHEEL="pre_commit-4.2.0-py2.py3-none-any.whl"
-        _PC_HASH="a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd"  # pragma: allowlist secret
-        _PC_DIR="$(mktemp -d)"
-        pip download "pre-commit==4.2.0" --no-deps -d "$_PC_DIR" -q
-        _ACTUAL="$(sha256sum "$_PC_DIR/$_PC_WHEEL" 2>/dev/null | cut -d' ' -f1 || \
-                   shasum -a 256 "$_PC_DIR/$_PC_WHEEL" | cut -d' ' -f1)"
-        if [ "$_ACTUAL" != "$_PC_HASH" ]; then
-            log "Hash mismatch for pre-commit wheel — aborting install" "$RED"
-            rm -rf "$_PC_DIR"
-            return 1
-        fi
-        pip install "$_PC_DIR/$_PC_WHEEL"
-        rm -rf "$_PC_DIR"
+        # --require-hashes pins the wheel by SHA256 (Scorecard-recognised pattern);
+        # --no-deps avoids needing hashes for transitive dependencies.
+        pip install \
+            --no-deps \
+            --require-hashes \
+            --hash=sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd \
+            "pre-commit==4.2.0"  # pragma: allowlist secret
         pre-commit install
     fi
 

--- a/.github/workflows/quality-consolidated.yml
+++ b/.github/workflows/quality-consolidated.yml
@@ -24,19 +24,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: "20"
-
       - name: Run markdownlint
         continue-on-error: true
-        run: |
-          # Use npx with pinned version to avoid unpinned global installs (Scorecard)
-          npx --yes markdownlint-cli2@0.14.0 || {
-            echo "::warning::Markdown linting found issues. Please review and fix when possible."
-            echo "Note: This is currently non-blocking to allow gradual improvement"
-          }
+        uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9 # v23.0.0
+        with:
+          globs: "**/*.md"
 
   # Rust code quality checks
   rust-quality:


### PR DESCRIPTION
## Summary

- Replaces `npx --yes markdownlint-cli2@0.14.0` with `DavidAnson/markdownlint-cli2-action` pinned by commit SHA (closes Scorecard alert #254)
- Removes bare `npm install --ignore-scripts` fallback that ran without a lockfile — now warns to commit a lockfile instead (closes alert #295)
- Rewrites the `pip pre-commit` install to use `--require-hashes` which is the pattern Scorecard explicitly recognises, replacing the manual download-and-verify approach (closes alert #296)
- Drops unused `setup-node` step from the markdown-lint job

**Branch protection** was also enabled on `main` (no-admin-bypass off, 0 required approvals) to address the `Branch-Protection` Scorecard finding.

## Test plan

- [ ] CI passes on this PR
- [ ] Next weekly Scorecard run clears alerts #254, #295, #296
- [ ] markdownlint-cli2-action runs without errors (uses existing `.markdownlint-cli2.jsonc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve dependency security checks and Markdown linting in CI to satisfy Scorecard requirements.

Enhancements:
- Warn when Node projects lack a package-lock.json and skip npm checks instead of generating a lockfile on CI.
- Install the pre-commit Python package via pip with SHA256-pinned, hash-required installation while avoiding transitive dependency hashes.

CI:
- Replace the npx-based markdownlint invocation with the SHA-pinned DavidAnson/markdownlint-cli2 GitHub Action and configure it to lint Markdown files.
- Remove the unused Node.js setup step from the consolidated quality workflow.