### PR TITLE
fix(ci): remove v0.6.0 stale refs and fix clippy raw-string lint

### DIFF
--- a/.github/workflows/performance-consolidated.yml
+++ b/.github/workflows/performance-consolidated.yml
@@ -181,12 +181,12 @@ jobs:
           cat plain_bench.md >> benchmark_results.md
           echo "" >> benchmark_results.md
 
-          # Highlight mode benchmark
-          echo "### Highlight Mode" >> benchmark_results.md
+          # AST mode benchmark
+          echo "### AST Mode" >> benchmark_results.md
           hyperfine --warmup 3 --runs 10 \
-            './target/release/batless benchmark_files/medium.rs --mode=highlight' \
-            --export-markdown highlight_bench.md
-          cat highlight_bench.md >> benchmark_results.md
+            './target/release/batless benchmark_files/medium.rs --mode=ast' \
+            --export-markdown ast_bench.md
+          cat ast_bench.md >> benchmark_results.md
           echo "" >> benchmark_results.md
 
           # JSON mode benchmark

--- a/benches/performance.rs
+++ b/benches/performance.rs
@@ -1,4 +1,4 @@
-use batless::{highlight_content, process_file, BatlessConfig, LanguageDetector, ThemeManager};
+use batless::{process_file, BatlessConfig, LanguageDetector};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use std::hint::black_box;
 use std::io::Write;
@@ -27,38 +27,6 @@ fn benchmark_process_file(c: &mut Criterion) {
             &(file.path().to_str().unwrap(), &config),
             |b, (path, config)| b.iter(|| black_box(process_file(path, config).unwrap())),
         );
-    }
-
-    group.finish();
-}
-
-fn benchmark_highlight_content(c: &mut Criterion) {
-    let mut group = c.benchmark_group("highlight_content");
-
-    let test_cases = vec![
-        (
-            "rust",
-            "fn main() {\n    println!(\"Hello, world!\");\n}",
-            "test.rs",
-        ),
-        (
-            "python",
-            "def main():\n    print('Hello, world!')\n",
-            "test.py",
-        ),
-        ("json", r#"{"hello": "world", "number": 42}"#, "test.json"),
-        (
-            "plain",
-            "This is plain text\nwith multiple lines\n",
-            "test.txt",
-        ),
-    ];
-
-    for (lang, content, filename) in test_cases {
-        let config = BatlessConfig::default();
-        group.bench_function(lang, |b| {
-            b.iter(|| black_box(highlight_content(content, filename, &config).unwrap()))
-        });
     }
 
     group.finish();
@@ -140,30 +108,16 @@ fn benchmark_max_lines_limits(c: &mut Criterion) {
 fn benchmark_startup_operations(c: &mut Criterion) {
     let mut group = c.benchmark_group("startup_operations");
 
-    // Benchmark operations that should be fast and not load heavy syntax sets
     group.bench_function("list_languages", |b| {
         b.iter(|| black_box(LanguageDetector::list_languages()))
     });
 
-    group.bench_function("list_themes", |b| {
-        b.iter(|| black_box(ThemeManager::list_themes()))
-    });
-
-    // Benchmark config loading with precedence
     group.bench_function("config_default", |b| {
         b.iter(|| black_box(BatlessConfig::default()))
     });
 
     group.bench_function("config_load_with_precedence", |b| {
         b.iter(|| black_box(BatlessConfig::load_with_precedence().unwrap()))
-    });
-
-    // Benchmark validation operations
-    group.bench_function("validate_theme", |b| {
-        b.iter(|| {
-            ThemeManager::validate_theme("base16-ocean.dark").unwrap();
-            black_box(())
-        })
     });
 
     group.bench_function("validate_language", |b| {
@@ -213,7 +167,6 @@ fn benchmark_config_operations(c: &mut Criterion) {
 criterion_group!(
     benches,
     benchmark_process_file,
-    benchmark_highlight_content,
     benchmark_summary_mode,
     benchmark_max_lines_limits,
     benchmark_startup_operations,

--- a/src/config.rs
+++ b/src/config.rs
@@ -645,11 +645,11 @@ mod tests {
         use std::io::Write;
         use tempfile::NamedTempFile;
 
-        let toml_content = r#"
+        let toml_content = r"
 max_lines = 15000
 use_color = false
 summary_mode = true
-"#;
+";
 
         let mut temp_file = NamedTempFile::new().unwrap();
         temp_file.write_all(toml_content.as_bytes()).unwrap();


### PR DESCRIPTION
## Summary

Three CI failures caused by symbols and modes removed when syntect was dropped in v0.6.0, but not cleaned up:

- **`src/config.rs:648`** — `r#"..."#` → `r"..."` fixes `clippy::needless_raw_string_hashes` (denied by `-D warnings`, causing Comprehensive Testing and Code Quality failures)
- **`benches/performance.rs`** — removes `benchmark_highlight_content` and all `ThemeManager` references (`highlight_content` and `ThemeManager` were deleted in v0.6.0); fixes benchmark compile error
- **`.github/workflows/performance-consolidated.yml`** — replaces `--mode=highlight` (exits 2 since v0.6.0) with `--mode=ast` (added in v0.6.0); fixes Performance Management run

Closes #130 (auto-opened by the performance regression detector when benchmarks failed).

## Test plan

- [ ] CI passes (Comprehensive Testing, Code Quality & Security, Performance Management)
- [ ] `cargo clippy --tests -- -D warnings` clean locally ✅
- [ ] `cargo check --benches` clean locally ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clean up stale highlighting-related references removed in v0.6.0 to restore CI and performance benchmarks.

Bug Fixes:
- Fix clippy raw-string lint in configuration tests to unblock CI with -D warnings.
- Update performance workflow to benchmark AST mode instead of the removed highlight mode, fixing performance job failures.
- Remove obsolete theme-related benchmarks and the unused benchmark_highlight_content entry so performance benchmarks compile again.

Tests:
- Adjust benchmark suite by dropping outdated theme and highlight-content benchmarks that depended on removed APIs.