### PR TITLE
fix(scripts): add require_last_push_approval to merge-own-pr.sh

### DIFF
--- a/.github/scripts/merge-own-pr.sh
+++ b/.github/scripts/merge-own-pr.sh
@@ -13,7 +13,8 @@ STRICT_BP='{
   "required_pull_request_reviews": {
     "required_approving_review_count": 1,
     "dismiss_stale_reviews": true,
-    "require_code_owner_reviews": true
+    "require_code_owner_reviews": true,
+    "require_last_push_approval": true
   },
   "restrictions": null,
   "required_linear_history": true
@@ -25,7 +26,8 @@ RELAXED_BP='{
   "required_pull_request_reviews": {
     "required_approving_review_count": 0,
     "dismiss_stale_reviews": true,
-    "require_code_owner_reviews": false
+    "require_code_owner_reviews": false,
+    "require_last_push_approval": false
   },
   "restrictions": null,
   "required_linear_history": true


### PR DESCRIPTION
Replaces #148 (had merge conflicts after rebase).

The relaxed branch-protection payload in `merge-own-pr.sh` was missing `require_last_push_approval: false`, causing the merge to fail with a 405 when legacy branch protection has that flag enabled. Adds the flag to both RELAXED and STRICT payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent merge failures when legacy branch protection requires last-push approval by explicitly setting the require_last_push_approval flag in both strict and relaxed configurations.