### PR TITLE
fix(security): add OpenSSF Scorecard workflow and harden SECURITY.md

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,38 @@
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '20 14 * * 1'
+  push:
+    branches: ["main"]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
+        with:
+          sarif_file: results.sarif
+          category: scorecard

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Symbol indexes, token-estimated context, semantic chunks — structured output t
 [![Security](https://github.com/docdyhr/batless/actions/workflows/security.yml/badge.svg?branch=main)](https://github.com/docdyhr/batless/actions/workflows/security.yml)
 [![Fuzz Testing](https://github.com/docdyhr/batless/actions/workflows/fuzz.yml/badge.svg?branch=main)](https://github.com/docdyhr/batless/actions/workflows/fuzz.yml)
 [![Codecov](https://codecov.io/gh/docdyhr/batless/branch/main/graph/badge.svg?logo=codecov&logoColor=white)](https://codecov.io/gh/docdyhr/batless)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/docdyhr/batless/badge)](https://securityscorecards.dev/viewer/?uri=github.com/docdyhr/batless)
 
 [![Rust](https://img.shields.io/badge/Rust-100%25-orange?logo=rust&logoColor=white)](https://github.com/docdyhr/batless)
 [![Security Tests](https://img.shields.io/badge/security%20tests-passing-brightgreen?logo=shield&logoColor=white)](https://github.com/docdyhr/batless)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ We take security vulnerabilities seriously. If you discover a security issue in 
 ### Reporting Process
 
 1. **Do NOT create a public issue** for security vulnerabilities
-2. Email security concerns to: [security@batless.dev] (or create a private security advisory on GitHub)
+2. **Use GitHub's private vulnerability reporting**: https://github.com/docdyhr/batless/security/advisories/new
 3. Include the following information:
    - Description of the vulnerability
    - Steps to reproduce the issue
@@ -91,9 +91,7 @@ We recognize security researchers who help improve batless security:
 
 ### Contact Information
 
-- **Security Email**: [INSERT EMAIL]
-- **PGP Key**: [INSERT PGP KEY ID if available]
-- **GitHub Security Advisories**: Use GitHub's private vulnerability reporting feature
+- **GitHub Security Advisories**: https://github.com/docdyhr/batless/security/advisories/new
 
 ### Legal
 


### PR DESCRIPTION
## Summary

Addresses the three OpenSSF Scorecard findings from the latest scan.

- **Branch-Protection (score 3→expected improvement)**: Adds `scorecard.yml` so Scorecard runs with `GITHUB_TOKEN` and can read the existing repository ruleset. Results are published to the OpenSSF API and uploaded to GitHub Code Scanning (SARIF).
- **CII-Best-Practices**: Enables GitHub private vulnerability reporting (GHSA) and removes placeholder emails from `SECURITY.md`, replacing them with the GitHub Security Advisories URL.
- **Code-Review (score 0)**: No automated fix possible for a solo project — approved Dependabot merges will accumulate over time. The Scorecard workflow will track this going forward.

## Changes

- `.github/workflows/scorecard.yml` — new workflow using `ossf/scorecard-action@v2.4.3` (pinned SHA), runs weekly + on push to main + on branch-protection-rule events
- `SECURITY.md` — remove `[security@batless.dev]`, `[INSERT EMAIL]`, `[INSERT PGP KEY ID]` placeholders; replace with `https://github.com/docdyhr/batless/security/advisories/new`
- `README.md` — add OpenSSF Scorecard badge
- Private vulnerability reporting enabled on the repository via API

## Test plan

- [ ] CI passes on this PR
- [ ] Scorecard workflow runs successfully after merge (visible in Actions tab)
- [ ] OpenSSF Scorecard badge resolves after first successful run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add automated OpenSSF Scorecard supply-chain security analysis and tighten documented security reporting channels.

New Features:
- Introduce a GitHub Actions workflow to run OpenSSF Scorecard on a schedule and on key repository events, publishing results to code scanning and the OpenSSF API.

Enhancements:
- Update SECURITY.md to direct reporters to GitHub's private vulnerability reporting workflow instead of email-based placeholders.
- Add an OpenSSF Scorecard status badge to the README to surface supply-chain security posture.