### PR TITLE
fix(ci): use commit SHA for ossf/scorecard-action (not tag-object SHA)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Root cause

`ossf/scorecard-action@v2.4.3` is an **annotated tag**, so it has two distinct SHAs:

| | SHA |
|---|---|
| Tag object (wrong) | `99c09fe975337306107572b4fdf4db224cf8e2f2` |
| Commit (correct) | `4eaacf0543bb3f2c246792bd56e8cdeffafb205a` |

The Scorecard `publish_results: true` path sends the workflow SHA to the OpenSSF webapp for signature verification. The webapp checks that the SHA belongs to an actual **commit** in `ossf/scorecard-action`. Using the tag-object SHA caused:

```
error sending scorecard results to webapp: http response 400
workflow verification failed: imposter commit: 99c09fe... does not belong to ossf/scorecard-action
```

## Fix

Replace the tag-object SHA with the dereferenced commit SHA in `scorecard.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update the Scorecard workflow to use the ossf/scorecard-action commit SHA instead of the annotated tag-object SHA to satisfy OpenSSF verification.