### PR TITLE
fix(security): codeql v4, SLSA provenance attestation, remove admin bypass

### DIFF
--- a/.github/scripts/merge-own-pr.sh
+++ b/.github/scripts/merge-own-pr.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 # Usage: ./merge-own-pr.sh <PR_NUMBER>
-# Merges a PR authored by the repo owner by temporarily relaxing branch
-# protection (review count 0), squash-merging, then restoring (review count 1).
+# Squash-merges a PR authored by the repo owner by temporarily relaxing both
+# the legacy branch-protection rules and the "Protect main" ruleset, then
+# restoring strict settings (no admin bypass after restore).
 set -euo pipefail
 
 PR="${1:?Usage: $0 <PR_NUMBER>}"
 REPO="docdyhr/batless"
+RULESET_ID="15969824"
 
+# ── Legacy branch-protection (belt-and-suspenders) ──────────────────────────
 STRICT_BP='{
   "required_status_checks": {"strict": true, "contexts": ["CI Status"]},
   "enforce_admins": true,
@@ -33,15 +36,76 @@ RELAXED_BP='{
   "required_linear_history": true
 }'
 
+# ── Repository ruleset (no bypass_actors in strict — admins are enforced) ────
+STRICT_RULESET=$(cat <<'JSON'
+{
+  "name": "Protect main: require PR and CI",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {"ref_name": {"exclude": [], "include": ["~DEFAULT_BRANCH"]}},
+  "rules": [
+    {"type": "pull_request", "parameters": {
+      "required_approving_review_count": 1,
+      "dismiss_stale_reviews_on_push": true,
+      "required_reviewers": [],
+      "require_code_owner_review": true,
+      "require_last_push_approval": true,
+      "required_review_thread_resolution": false,
+      "allowed_merge_methods": ["squash"]
+    }},
+    {"type": "required_status_checks", "parameters": {
+      "strict_required_status_checks_policy": true,
+      "do_not_enforce_on_create": false,
+      "required_status_checks": [{"context": "CI Status"}]
+    }},
+    {"type": "deletion"},
+    {"type": "non_fast_forward"}
+  ],
+  "bypass_actors": []
+}
+JSON
+)
+
+RELAXED_RULESET=$(cat <<'JSON'
+{
+  "name": "Protect main: require PR and CI",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {"ref_name": {"exclude": [], "include": ["~DEFAULT_BRANCH"]}},
+  "rules": [
+    {"type": "pull_request", "parameters": {
+      "required_approving_review_count": 0,
+      "dismiss_stale_reviews_on_push": true,
+      "required_reviewers": [],
+      "require_code_owner_review": false,
+      "require_last_push_approval": false,
+      "required_review_thread_resolution": false,
+      "allowed_merge_methods": ["squash"]
+    }},
+    {"type": "required_status_checks", "parameters": {
+      "strict_required_status_checks_policy": true,
+      "do_not_enforce_on_create": false,
+      "required_status_checks": [{"context": "CI Status"}]
+    }},
+    {"type": "deletion"},
+    {"type": "non_fast_forward"}
+  ],
+  "bypass_actors": []
+}
+JSON
+)
+
 restore() {
     echo "Restoring branch protection..."
     echo "$STRICT_BP" | gh api --method PUT "repos/$REPO/branches/main/protection" --input - > /dev/null
-    echo "Branch protection restored (1 required review)."
+    echo "$STRICT_RULESET" | gh api --method PUT "repos/$REPO/rulesets/$RULESET_ID" --input - > /dev/null
+    echo "Branch protection restored (1 required review, no admin bypass)."
 }
 trap restore EXIT
 
 echo "Relaxing branch protection for merge..."
 echo "$RELAXED_BP" | gh api --method PUT "repos/$REPO/branches/main/protection" --input - > /dev/null
+echo "$RELAXED_RULESET" | gh api --method PUT "repos/$REPO/rulesets/$RULESET_ID" --input - > /dev/null
 
 echo "Merging PR #$PR..."
 gh api --method PUT "repos/$REPO/pulls/$PR/merge" -f merge_method=squash --jq '.message'

--- a/.github/workflows/release-consolidated.yml
+++ b/.github/workflows/release-consolidated.yml
@@ -81,6 +81,10 @@ jobs:
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     needs: [validate, test]
+    permissions:
+      attestations: write
+      id-token: write
+      contents: read
     strategy:
       matrix:
         include:
@@ -128,6 +132,11 @@ jobs:
           else
             tar -czf "batless-${{ matrix.target }}.tar.gz" -C "./target/${{ matrix.target }}/release" "$binary_name"
           fi
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: "batless-${{ matrix.target }}.*"
 
       - name: Upload release artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
           publish_results: true
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           sarif_file: results.sarif
           category: scorecard


### PR DESCRIPTION
## Summary

Three Scorecard issues fixed in one pass:

- **CodeQL deprecation warning** — `scorecard.yml` was the only workflow still on `codeql-action` v3 SHA. Updated to the v4 SHA already used everywhere else in `security.yml`.

- **Signed-Releases (0/10)** — `release-consolidated.yml` `build-release` job now calls `actions/attest-build-provenance@v4.1.0` immediately after packaging each platform binary, generating SLSA provenance attestations stored in the GitHub Attestations API. Scorecard will detect these on the next release.

- **Branch-Protection "apply to administrators" (8→9/10)** — `merge-own-pr.sh` extended to also relax/restore the `Protect main` ruleset (id 15969824) alongside the legacy branch-protection API. The strict-restore payload sets `bypass_actors: []`, so after this PR is merged the admin bypass actor is permanently removed from the ruleset, and Scorecard will no longer see `'branch protection settings apply to administrators' is disabled`.

## What won't change

- **Code-Review (0/10)** — solo project; will naturally improve as Dependabot PRs accumulate approved changesets.
- **CII-Best-Practices (2/10)** — badge registration is a manual step on bestpractices.coreinfrastructure.org.
- **Branch-Protection required_approving_review_count** — stays at 1; a solo project cannot require 2 reviewers without locking itself out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten repository security and supply-chain protections by updating security workflows, adding build provenance attestations, and ensuring branch protection rules fully apply to administrators.

New Features:
- Generate SLSA build provenance attestations for release artifacts using GitHub's attest-build-provenance action.

Enhancements:
- Update Scorecard workflow to use the latest v4 CodeQL SARIF upload action for code scanning.
- Extend the merge-own-pr helper script to relax and then strictly restore both legacy branch protection and the main branch ruleset with no admin bypass.