### PR TITLE
chore: add Railway deploy badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+<div align="right">
+
+<a href="https://railway.com?referralCode=QhjuBc">
+
+  <img width="160" src="https://raw.githubusercontent.com/docdyhr/.github/main/assets/railway-corner-v2@2x.png" alt="Deploy on Railway — $20 free credits">
+
+</a>
+
+</div>
+
 # 🦇 batless
 
 <div align="center">


### PR DESCRIPTION
Adds the Railway deploy badge to the top-right corner of the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Update the README to display a Railway deploy badge with referral link.