### PR TITLE
ci: migrate CodeQL to caller, deduplicate security jobs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,25 @@
+# Caller for the reusable CodeQL workflow in docdyhr/.github.
+# To upgrade across all consumers, re-tag v1 in docdyhr/.github.
+
+name: CodeQL Analysis
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  codeql:
+    uses: docdyhr/.github/.github/workflows/codeql.yml@v1
+    with:
+      languages: '["rust"]'
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/quality-consolidated.yml
+++ b/.github/workflows/quality-consolidated.yml
@@ -76,47 +76,6 @@ jobs:
             echo "Note: This check excludes test code and literal strings"
           fi
 
-  # Security auditing
-  security-audit:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Install Rust stable
-        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
-        with:
-          toolchain: stable
-
-      - name: Install cargo-audit
-        run: cargo install --locked cargo-audit
-
-      - name: Run security audit
-        run: cargo audit
-
-      - name: Run cargo deny
-        uses: EmbarkStudios/cargo-deny-action@a531616d8ce3b9177443e48a1159bc945a099823 # v2
-        continue-on-error: true
-        with:
-          log-level: warn
-          command: check
-          arguments: --all-features
-
-  # Dependency analysis
-  dependency-review:
-    name: Dependency Review
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Dependency Review
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4
-        with:
-          fail-on-severity: moderate
-
   # Code coverage
   coverage:
     name: Code Coverage
@@ -151,26 +110,3 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: false
-
-  # License compliance
-  license-check:
-    name: License Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Install Rust stable
-        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
-        with:
-          toolchain: stable
-
-      - name: Install cargo-license
-        run: cargo install --locked cargo-license
-
-      - name: Check licenses
-        run: |
-          cargo license --json | jq -r '.[] |
-          select(.license != "MIT" and .license != "Apache-2.0" and
-          .license != "BSD-3-Clause" and .license != "ISC") |
-          .name + ": " + .license'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -96,36 +96,6 @@ jobs:
           fail-on-severity: moderate
           allow-licenses: MIT, Apache-2.0, BSD-3-Clause, ISC, MPL-2.0
 
-  codeql-analysis:
-    name: CodeQL Analysis
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      contents: read
-      actions: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
-        with:
-          languages: rust
-          queries: +security-and-quality
-
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
-        with:
-          toolchain: stable
-
-      - name: Build for analysis
-        run: cargo build --all-features
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
-        with:
-          category: "/language:rust"
-
   semgrep:
     name: Semgrep Security Scan
     runs-on: ubuntu-latest
@@ -218,28 +188,3 @@ jobs:
         with:
           name: license-report
           path: licenses.json
-
-  security-scorecard:
-    name: OSSF Scorecard
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      id-token: write
-      contents: read
-      actions: read
-    steps:
-      - name: Run analysis
-        continue-on-error: true
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          publish_results: false
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload SARIF results
-        if: hashFiles('results.sarif') != ''
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
-        with:
-          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- **New `codeql.yml`** — 25-line thin caller to `docdyhr/.github/codeql.yml@v1` with `languages: rust`; this is the only blob-to-caller migration possible today given the org reusable library
- **`security.yml` -56 lines** (246→190): removed `codeql-analysis` job (superseded by `codeql.yml`) and `security-scorecard` job (duplicate of the standalone `scorecard.yml` which has `publish_results: true`)
- **`quality-consolidated.yml` -64 lines** (176→112): removed `security-audit`, `dependency-review`, and `license-check` — all three are authoritative in `security.yml` and were running twice on the same weekly schedule

## What's still blocked

The remaining 6 large workflows (`ci-optimized`, `test-consolidated`, `cross-platform-validation`, `release-consolidated`, `performance-consolidated`, `health-check`) are Rust-specific CI patterns with no matching reusable in `docdyhr/.github`. Migrating them requires publishing Rust CI reusable workflows upstream first.

## Test plan

- [ ] CodeQL Analysis workflow runs successfully on this PR
- [ ] Security Review workflow runs (no codeql-analysis job present, no scorecard job present)
- [ ] Code Quality & Security workflow runs (no security-audit, dependency-review, or license-check jobs)
- [ ] Scorecard workflow still runs independently on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Migrate CodeQL analysis to a centralized reusable workflow and remove duplicated security checks from consolidated CI workflows.

New Features:
- Introduce a dedicated CodeQL workflow that calls the shared reusable CodeQL configuration for Rust projects.

Enhancements:
- Deduplicate security-related jobs by removing security audit, dependency review, and license check from the quality-consolidated workflow in favor of their authoritative definitions in the security workflow.
- Remove the inlined CodeQL analysis and OSSF Scorecard jobs from the main security workflow to rely on the standalone CodeQL and Scorecard workflows.