### PR TITLE
fix(lint): resolve remaining clippy pedantic/nursery lints in main.rs and tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -299,7 +299,7 @@ fn handle_normal_processing(file_path: &str, manager: &ConfigManager) -> Batless
     }
 
     if args.count_tokens {
-        print_token_analysis(&file_info, args.ai_model.into())?;
+        print_token_analysis(&file_info, args.ai_model.into());
     }
 
     let file_info = if args.fit_context {
@@ -319,13 +319,16 @@ fn handle_normal_processing(file_path: &str, manager: &ConfigManager) -> Batless
     };
 
     // Attach estimated LLM token count when a profile or explicit model is active
-    let effective_model: Option<AiModel> = if let Some(profile) = args.profile {
-        Some(profile.get_ai_model())
-    } else if args.ai_model != CliAiModel::Generic {
-        Some(args.ai_model.into())
-    } else {
-        None
-    };
+    let effective_model: Option<AiModel> = args.profile.map_or_else(
+        || {
+            if args.ai_model == CliAiModel::Generic {
+                None
+            } else {
+                Some(args.ai_model.into())
+            }
+        },
+        |profile| Some(profile.get_ai_model()),
+    );
     let final_file_info = if let Some(model) = effective_model {
         let counter = TokenCounter::new(model);
         let token_count = counter.count_tokens(&file_info.lines.join("\n"));
@@ -364,7 +367,7 @@ fn handle_normal_processing(file_path: &str, manager: &ConfigManager) -> Batless
     Ok(())
 }
 
-fn print_token_analysis(file_info: &batless::FileInfo, model: AiModel) -> BatlessResult<()> {
+fn print_token_analysis(file_info: &batless::FileInfo, model: AiModel) {
     let content = file_info.lines.join("\n");
     let counter = TokenCounter::new(model);
     let token_count = counter.count_tokens(&content);
@@ -383,7 +386,6 @@ fn print_token_analysis(file_info: &batless::FileInfo, model: AiModel) -> Batles
     };
     println!("  Fits in context: {fits}");
     println!();
-    Ok(())
 }
 
 fn validate_json_output(json_output: &str) -> BatlessResult<()> {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -148,7 +148,7 @@ fn test_max_lines_limit() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    let lines: Vec<&str> = stdout.trim().split('\n').collect();
+    let lines: Vec<&str> = stdout.lines().collect();
 
     // Should have 3 content lines + 1 truncation message
     assert_eq!(lines.len(), 4);
@@ -371,7 +371,7 @@ fn test_total_lines_exact_flag() {
 
 #[test]
 fn test_token_sampling_reports_truncation() {
-    let repeated_tokens: Vec<String> = (0..3_000).map(|i| format!("token{}", i)).collect();
+    let repeated_tokens: Vec<String> = (0..3_000).map(|i| format!("token{i}")).collect();
     let content = repeated_tokens.join(" ");
     let file = create_test_file(&content, ".rs");
 
@@ -389,7 +389,7 @@ fn test_token_sampling_reports_truncation() {
     let token_count = json["identifier_count"].as_u64().expect("token_count");
 
     assert!(
-        token_count as usize > tokens.len(),
+        usize::try_from(token_count).expect("token_count fits in usize") > tokens.len(),
         "Reported count should exceed sampled tokens"
     );
     assert_eq!(json["identifiers_truncated"], true);
@@ -475,8 +475,7 @@ fn test_ai_profile_copilot() {
     // Should be JSON output with tokens
     assert!(
         stdout.contains("\"language\": \"Rust\"") || stdout.contains("\"language\":\"Rust\""),
-        "Expected language Rust field in JSON output, got: {}",
-        stdout
+        "Expected language Rust field in JSON output, got: {stdout}"
     );
     assert!(stdout.contains("\"identifiers\":"));
 }
@@ -491,8 +490,7 @@ fn test_ai_profile_chatgpt() {
     // Should be JSON output with tokens
     assert!(
         stdout.contains("\"language\": \"Python\"") || stdout.contains("\"language\":\"Python\""),
-        "Expected language Python field in JSON output, got: {}",
-        stdout
+        "Expected language Python field in JSON output, got: {stdout}"
     );
     assert!(stdout.contains("\"identifiers\":"));
 }
@@ -522,7 +520,7 @@ fn test_explicit_mode_overrides_profile() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     // Explicit --mode=json should win over claude profile's summary default
-    assert!(stdout.starts_with("{"));
+    assert!(stdout.starts_with('{'));
     assert!(!stdout.contains("=== File Summary ==="));
 }
 
@@ -535,7 +533,7 @@ fn test_profile_default_mode_used_without_explicit_mode() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     // Without explicit --mode, claude profile's summary default applies
     assert!(stdout.contains("=== File Summary ==="));
-    assert!(!stdout.starts_with("{"));
+    assert!(!stdout.starts_with('{'));
 }
 
 #[test]
@@ -593,8 +591,7 @@ fn test_stdin_processing() {
     assert!(stdout.contains("test line 2"));
     assert!(
         stdout.contains("file\": \"-") || stdout.contains("file\":\"-"),
-        "Expected file path '-' marker in JSON output, got: {}",
-        stdout
+        "Expected file path '-' marker in JSON output, got: {stdout}"
     );
 }
 
@@ -930,8 +927,7 @@ fn test_strip_compression_ratio_in_json() {
         .expect("compression_ratio should be a float");
     assert!(
         ratio > 1.0,
-        "compression_ratio should be > 1.0 when content was stripped, got {}",
-        ratio
+        "compression_ratio should be > 1.0 when content was stripped, got {ratio}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Convert `if let Some(profile)` chain to `map_or_else` in `effective_model` assignment (`option_if_let_else`)
- Remove unnecessary `BatlessResult<()>` return from `print_token_analysis` — function never returns an error (`unnecessary_wraps`)
- Replace `.trim().split('\n')` with `.lines()` in integration test (`str_split_at_newline`)
- Use `usize::try_from` instead of `as usize` cast for `token_count` (`cast_possible_truncation`)

Completes the clippy cleanup started in #165. All 366 tests pass; pre-commit hooks (fmt + clippy) pass locally.

## Test plan

- [x] `cargo clippy --tests -- -W clippy::pedantic -W clippy::nursery -W clippy::cargo -D warnings` — no errors
- [x] `cargo test` — 366 passed, 0 failed
- [ ] Code Quality & Security workflow passes on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Resolve remaining clippy pedantic/nursery lints in main processing logic and integration tests.

Enhancements:
- Simplify effective model selection and token analysis handling in main processing flow, including making token analysis a non-fallible operation.

Tests:
- Tighten and modernize integration tests to use idiomatic string handling, safe integer conversion, and clearer assertion messages.