### PR TITLE
fix(lint): resolve clippy warnings in tests, benches, and examples

### DIFF
--- a/benches/performance.rs
+++ b/benches/performance.rs
@@ -14,7 +14,7 @@ fn benchmark_process_file(c: &mut Criterion) {
     let mut group = c.benchmark_group("process_file");
 
     // Test with different file sizes
-    let sizes = vec![1000, 10000, 100000];
+    let sizes = vec![1000, 10_000, 100_000];
 
     for size in sizes {
         let content = "fn main() {\n    println!(\"Hello, world!\");\n}\n".repeat(size / 50);
@@ -75,11 +75,11 @@ fn main() {
     };
 
     c.bench_function("summary_mode_enabled", |b| {
-        b.iter(|| black_box(process_file(file.path().to_str().unwrap(), &summary_config).unwrap()))
+        b.iter(|| black_box(process_file(file.path().to_str().unwrap(), &summary_config).unwrap()));
     });
 
     c.bench_function("summary_mode_disabled", |b| {
-        b.iter(|| black_box(process_file(file.path().to_str().unwrap(), &regular_config).unwrap()))
+        b.iter(|| black_box(process_file(file.path().to_str().unwrap(), &regular_config).unwrap()));
     });
 }
 
@@ -89,7 +89,7 @@ fn benchmark_max_lines_limits(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("max_lines");
 
-    for max_lines in [100, 1000, 5000, 10000].iter() {
+    for max_lines in &[100, 1000, 5000, 10000] {
         let config = BatlessConfig {
             max_lines: *max_lines,
             ..Default::default()
@@ -109,22 +109,22 @@ fn benchmark_startup_operations(c: &mut Criterion) {
     let mut group = c.benchmark_group("startup_operations");
 
     group.bench_function("list_languages", |b| {
-        b.iter(|| black_box(LanguageDetector::list_languages()))
+        b.iter(|| black_box(LanguageDetector::list_languages()));
     });
 
     group.bench_function("config_default", |b| {
-        b.iter(|| black_box(BatlessConfig::default()))
+        b.iter(|| black_box(BatlessConfig::default()));
     });
 
     group.bench_function("config_load_with_precedence", |b| {
-        b.iter(|| black_box(BatlessConfig::load_with_precedence().unwrap()))
+        b.iter(|| black_box(BatlessConfig::load_with_precedence().unwrap()));
     });
 
     group.bench_function("validate_language", |b| {
         b.iter(|| {
             LanguageDetector::validate_language("rust").unwrap();
-            black_box(())
-        })
+            black_box(());
+        });
     });
 
     group.finish();
@@ -156,8 +156,8 @@ fn benchmark_config_operations(c: &mut Criterion) {
         group.bench_function(name, |b| {
             b.iter(|| {
                 config.validate().unwrap();
-                black_box(())
-            })
+                black_box(());
+            });
         });
     }
 

--- a/examples/theme-showcase.rs
+++ b/examples/theme-showcase.rs
@@ -2,7 +2,6 @@
 // This file demonstrates syntax highlighting across various themes
 
 use std::collections::HashMap;
-use std::io;
 
 /// Configuration struct for the application
 #[derive(Debug, Clone)]
@@ -14,6 +13,7 @@ pub struct Config {
 
 impl Config {
     /// Creates a new configuration with default values
+    #[must_use]
     pub fn new(name: &str) -> Self {
         Self {
             name: name.to_string(),
@@ -24,38 +24,35 @@ impl Config {
 }
 
 /// Main application logic
-fn main() -> io::Result<()> {
+fn main() {
     // Initialize configuration
     let config = Config::new("batless");
     let mut cache: HashMap<String, Vec<u8>> = HashMap::new();
 
     // Process data
     for i in 0..10 {
-        let key = format!("item_{}", i);
-        let value = vec![i as u8; i];
+        let key = format!("item_{i}");
+        let value = vec![u8::try_from(i).unwrap_or(u8::MAX); i];
         cache.insert(key, value);
     }
 
     // Print results
-    println!("Configuration: {:?}", config);
+    println!("Configuration: {config:?}");
     println!("Cache size: {}", cache.len());
 
     // Conditional logic
     if config.enabled {
-        process_data(&cache)?;
+        process_data(&cache);
     } else {
         eprintln!("Processing disabled!");
     }
-
-    Ok(())
 }
 
 /// Processes cached data
-fn process_data(cache: &HashMap<String, Vec<u8>>) -> io::Result<()> {
-    for (key, value) in cache.iter() {
+fn process_data(cache: &HashMap<String, Vec<u8>>) {
+    for (key, value) in cache {
         println!("Key: {}, Value size: {}", key, value.len());
     }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/file_info.rs
+++ b/src/file_info.rs
@@ -350,7 +350,7 @@ mod tests {
             .with_original_lines(Some(lines.clone()))
             .with_total_lines_exact(false)
             .with_tokens(Some(tokens.clone()))
-            .with_summary_lines(Some(summary.clone()));
+            .with_summary_lines(Some(summary));
 
         assert_eq!(info.lines, lines);
         assert!(info.truncated);

--- a/tests/ast_summarizer_js_ts_test.rs
+++ b/tests/ast_summarizer_js_ts_test.rs
@@ -5,7 +5,7 @@ use batless::summary::SummaryLevel;
 
 #[test]
 fn test_javascript_basic_summary() {
-    let code = r#"
+    let code = r"
 import React from 'react';
 import { useState } from 'react';
 
@@ -25,11 +25,11 @@ class Counter {
 }
 
 export default App;
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("JavaScript"), SummaryLevel::Standard);
 
-    println!("JS Summary: {:?}", summary);
+    println!("JS Summary: {summary:?}");
 
     // Should capture imports
     assert!(summary.iter().any(|l| l.line.contains("import React")));
@@ -50,7 +50,7 @@ export default App;
 
 #[test]
 fn test_javascript_arrow_functions() {
-    let code = r#"
+    let code = r"
 const add = (a, b) => a + b;
 
 const multiply = (x, y) => {
@@ -60,11 +60,11 @@ const multiply = (x, y) => {
 const Component = () => {
     return <div>Hello</div>;
 };
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("JavaScript"), SummaryLevel::Standard);
 
-    println!("Arrow function summary: {:?}", summary);
+    println!("Arrow function summary: {summary:?}");
 
     // Arrow functions should be captured
     assert!(summary.iter().any(|l| l.line.contains("=>")));
@@ -72,7 +72,7 @@ const Component = () => {
 
 #[test]
 fn test_javascript_es6_classes() {
-    let code = r#"
+    let code = r"
 class Animal {
     constructor(name) {
         this.name = name;
@@ -88,7 +88,7 @@ class Dog extends Animal {
         console.log(`${this.name} barks`);
     }
 }
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("JavaScript"), SummaryLevel::Standard);
 
@@ -99,7 +99,7 @@ class Dog extends Animal {
 
 #[test]
 fn test_javascript_async_await() {
-    let code = r#"
+    let code = r"
 async function fetchData() {
     const response = await fetch('/api/data');
     return response.json();
@@ -109,11 +109,11 @@ const processData = async () => {
     const data = await fetchData();
     return data;
 };
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("JavaScript"), SummaryLevel::Standard);
 
-    println!("Async JS summary: {:?}", summary);
+    println!("Async JS summary: {summary:?}");
 
     assert!(summary
         .iter()
@@ -123,12 +123,12 @@ const processData = async () => {
 
 #[test]
 fn test_javascript_exports() {
-    let code = r#"
+    let code = r"
 export function helper() {}
 export const API_KEY = 'secret'; // pragma: allowlist secret
 export default class Main {}
 export { utils };
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("JavaScript"), SummaryLevel::Standard);
 
@@ -140,7 +140,7 @@ export { utils };
 
 #[test]
 fn test_typescript_basic_summary() {
-    let code = r#"
+    let code = r"
 import { Component } from 'react';
 
 interface User {
@@ -167,11 +167,11 @@ function processUser(user: User): string {
 }
 
 export { UserService, processUser };
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("TypeScript"), SummaryLevel::Standard);
 
-    println!("TS Summary: {:?}", summary);
+    println!("TS Summary: {summary:?}");
 
     // Should capture imports
     assert!(summary.iter().any(|l| l.line.contains("import")));
@@ -198,7 +198,7 @@ export { UserService, processUser };
 
 #[test]
 fn test_typescript_interfaces() {
-    let code = r#"
+    let code = r"
 interface Animal {
     name: string;
     age: number;
@@ -214,7 +214,7 @@ interface Cat extends Animal {
     indoor: boolean;
     meow(): void;
 }
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("TypeScript"), SummaryLevel::Standard);
 
@@ -225,7 +225,7 @@ interface Cat extends Animal {
 
 #[test]
 fn test_typescript_enums() {
-    let code = r#"
+    let code = r"
 enum Color {
     Red,
     Green,
@@ -241,11 +241,11 @@ enum Status {
 function getColor(): Color {
     return Color.Red;
 }
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("TypeScript"), SummaryLevel::Detailed);
 
-    println!("Enum summary: {:?}", summary);
+    println!("Enum summary: {summary:?}");
 
     assert!(summary.iter().any(|l| l.line.contains("enum Color")));
     assert!(summary.iter().any(|l| l.line.contains("enum Status")));
@@ -254,7 +254,7 @@ function getColor(): Color {
 
 #[test]
 fn test_typescript_generics() {
-    let code = r#"
+    let code = r"
 interface Box<T> {
     value: T;
 }
@@ -274,7 +274,7 @@ class Container<T> {
 function identity<T>(arg: T): T {
     return arg;
 }
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("TypeScript"), SummaryLevel::Standard);
 
@@ -286,7 +286,7 @@ function identity<T>(arg: T): T {
 
 #[test]
 fn test_typescript_decorators() {
-    let code = r#"
+    let code = r"
 function Component(target: any) {
     // decorator logic
 }
@@ -306,11 +306,11 @@ class MyComponent {
         this.value = newValue;
     }
 }
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("TypeScript"), SummaryLevel::Standard);
 
-    println!("Decorator summary: {:?}", summary);
+    println!("Decorator summary: {summary:?}");
 
     assert!(summary
         .iter()
@@ -320,7 +320,7 @@ class MyComponent {
 
 #[test]
 fn test_typescript_react_component() {
-    let code = r#"
+    let code = r"
 import React, { FC, useState } from 'react';
 
 interface Props {
@@ -340,7 +340,7 @@ const Counter: FC<Props> = ({ title, count = 0 }) => {
 };
 
 export default Counter;
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("TypeScript"), SummaryLevel::Standard);
 
@@ -352,13 +352,13 @@ export default Counter;
 
 #[test]
 fn test_javascript_minimal_level() {
-    let code = r#"
+    let code = r"
 import utils from './utils';
 
 function main() {}
 class App {}
 const handler = () => {};
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("JavaScript"), SummaryLevel::Minimal);
 
@@ -373,13 +373,13 @@ const handler = () => {};
 
 #[test]
 fn test_typescript_minimal_level() {
-    let code = r#"
+    let code = r"
 import { User } from './types';
 
 interface Config {}
 class Service {}
 function process() {}
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("TypeScript"), SummaryLevel::Minimal);
 

--- a/tests/ast_summarizer_python_test.rs
+++ b/tests/ast_summarizer_python_test.rs
@@ -20,7 +20,7 @@ class User:
 
     let summary = AstSummarizer::extract_summary(code, Some("Python"), SummaryLevel::Standard);
 
-    println!("Summary: {:?}", summary);
+    println!("Summary: {summary:?}");
 
     // Check for function definitions
     assert!(summary.iter().any(|l| l.line.contains("def main")));
@@ -41,7 +41,7 @@ class User:
 
 #[test]
 fn test_python_ast_minimal_level() {
-    let code = r#"
+    let code = r"
 import os
 
 def hello():
@@ -49,7 +49,7 @@ def hello():
 
 class World:
     pass
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("Python"), SummaryLevel::Minimal);
 
@@ -63,7 +63,7 @@ class World:
 
 #[test]
 fn test_python_ast_decorators() {
-    let code = r#"
+    let code = r"
 @staticmethod
 def static_method():
     pass
@@ -75,11 +75,11 @@ def class_method(cls):
 @property
 def my_property(self):
     return self._value
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("Python"), SummaryLevel::Standard);
 
-    println!("Decorator summary: {:?}", summary);
+    println!("Decorator summary: {summary:?}");
 
     // Should capture decorated functions
     assert!(summary.iter().any(|l| l.line.contains("@staticmethod")));
@@ -89,18 +89,18 @@ def my_property(self):
 
 #[test]
 fn test_python_ast_async_functions() {
-    let code = r#"
+    let code = r"
 async def fetch_data():
     await get_data()
 
 async def process():
     result = await fetch_data()
     return result
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("Python"), SummaryLevel::Standard);
 
-    println!("Async summary: {:?}", summary);
+    println!("Async summary: {summary:?}");
 
     // Should capture async functions
     assert!(summary
@@ -114,18 +114,18 @@ async def process():
 
 #[test]
 fn test_python_ast_from_imports() {
-    let code = r#"
+    let code = r"
 from os import path
 from typing import List, Dict, Optional
 from .models import User, Post
 
 def process_user(user: User) -> Dict:
     return user.to_dict()
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("Python"), SummaryLevel::Standard);
 
-    println!("From import summary: {:?}", summary);
+    println!("From import summary: {summary:?}");
 
     // Should capture from imports
     assert!(summary.iter().any(|l| l.line.contains("from os import")));
@@ -142,7 +142,7 @@ def process_user(user: User) -> Dict:
 
 #[test]
 fn test_python_ast_nested_classes() {
-    let code = r#"
+    let code = r"
 class Outer:
     class Inner:
         def inner_method(self):
@@ -150,11 +150,11 @@ class Outer:
 
     def outer_method(self):
         pass
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("Python"), SummaryLevel::Standard);
 
-    println!("Nested class summary: {:?}", summary);
+    println!("Nested class summary: {summary:?}");
 
     // Should capture both outer and inner classes
     assert!(summary.iter().any(|l| l.line.contains("class Outer")));
@@ -165,13 +165,13 @@ class Outer:
 
 #[test]
 fn test_python_ast_lambda_ignored() {
-    let code = r#"
+    let code = r"
 def regular_function():
     mapper = lambda x: x * 2
     return mapper
 
 square = lambda x: x ** 2
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("Python"), SummaryLevel::Standard);
 
@@ -221,7 +221,7 @@ class MyClass:
 
 #[test]
 fn test_python_ast_detailed_level() {
-    let code = r#"
+    let code = r"
 import os
 
 MAX_SIZE = 1000
@@ -230,11 +230,11 @@ def process():
     global MAX_SIZE
     local_var = 42
     return local_var
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("Python"), SummaryLevel::Detailed);
 
-    println!("Detailed summary: {:?}", summary);
+    println!("Detailed summary: {summary:?}");
 
     // Detailed should include imports, functions, and module-level assignments
     assert!(summary.iter().any(|l| l.line.contains("import os")));
@@ -245,10 +245,10 @@ def process():
 
 #[test]
 fn test_python_ast_none_level() {
-    let code = r#"
+    let code = r"
 def my_function():
     pass
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("Python"), SummaryLevel::None);
 
@@ -257,7 +257,7 @@ def my_function():
 
 #[test]
 fn test_python_ast_complex_decorators() {
-    let code = r#"
+    let code = r"
 @app.route('/api/users')
 @login_required
 @cache(timeout=300)
@@ -269,11 +269,11 @@ def get_users():
 class Config:
     debug: bool
     port: int
-"#;
+";
 
     let summary = AstSummarizer::extract_summary(code, Some("Python"), SummaryLevel::Standard);
 
-    println!("Complex decorator summary: {:?}", summary);
+    println!("Complex decorator summary: {summary:?}");
 
     // Should capture first decorator of each decorated definition and the definition itself
     assert!(summary.iter().any(|l| l.line.contains("@app.route")));

--- a/tests/ast_summarizer_test.rs
+++ b/tests/ast_summarizer_test.rs
@@ -22,7 +22,7 @@ impl User {
     let summary = AstSummarizer::extract_summary(code, Some("Rust"), SummaryLevel::Standard);
 
     // Debug output
-    println!("Summary: {:?}", summary);
+    println!("Summary: {summary:?}");
 
     assert!(summary.iter().any(|l| l.line.contains("fn main")));
     assert!(summary.iter().any(|l| l.line.contains("struct User")));

--- a/tests/cli_coverage_tests.rs
+++ b/tests/cli_coverage_tests.rs
@@ -1,4 +1,4 @@
-//! Additional CLI integration tests to improve coverage for main.rs and config_manager.rs
+//! Additional CLI integration tests to improve coverage for main.rs and `config_manager.rs`
 //! Focuses on edge cases, error handling, and command combinations not covered elsewhere
 
 use std::io::Write;
@@ -176,7 +176,7 @@ fn test_streaming_json_with_checkpoints() {
     let mut temp_file = NamedTempFile::new().expect("Failed to create temp file");
     // Create a larger file for streaming
     for i in 0..100 {
-        writeln!(temp_file, "Line number {} with some content", i).expect("Failed to write");
+        writeln!(temp_file, "Line number {i} with some content").expect("Failed to write");
     }
     let temp_path = temp_file.path().to_str().expect("Invalid temp path");
 
@@ -223,7 +223,7 @@ fn test_fit_context_with_prompt_tokens() {
     let mut temp_file = NamedTempFile::new().expect("Failed to create temp file");
     // Create a very large file to test context fitting
     for i in 0..1000 {
-        writeln!(temp_file, "This is line {} with substantial content to test context window fitting and truncation behavior.", i).expect("Failed to write");
+        writeln!(temp_file, "This is line {i} with substantial content to test context window fitting and truncation behavior.").expect("Failed to write");
     }
     let temp_path = temp_file.path().to_str().expect("Invalid temp path");
 

--- a/tests/streaming_coverage_tests.rs
+++ b/tests/streaming_coverage_tests.rs
@@ -1,5 +1,5 @@
 //! Additional streaming functionality tests to improve coverage for streaming.rs
-//! Focuses on StreamingCheckpoint functionality and edge cases
+//! Focuses on `StreamingCheckpoint` functionality and edge cases
 
 use batless::{BatlessConfig, StreamingCheckpoint};
 use std::io::Write;
@@ -144,8 +144,7 @@ fn test_streaming_processor_with_stdin() {
     if let Err(error) = result {
         assert!(
             error.to_string().contains("Resume/checkpoint") || error.to_string().contains("stdin"),
-            "Error should mention checkpoint/stdin incompatibility: {}",
-            error
+            "Error should mention checkpoint/stdin incompatibility: {error}"
         );
     }
 }
@@ -169,8 +168,7 @@ fn test_streaming_processor_checkpoint_file_mismatch() {
     if let Err(error) = result {
         assert!(
             error.to_string().contains("file path") || error.to_string().contains("doesn't match"),
-            "Error should mention file path mismatch: {}",
-            error
+            "Error should mention file path mismatch: {error}"
         );
     }
 }
@@ -195,8 +193,7 @@ fn test_streaming_processor_incompatible_checkpoint() {
         assert!(
             error.to_string().contains("incompatible")
                 || error.to_string().contains("configuration"),
-            "Error should mention incompatibility: {}",
-            error
+            "Error should mention incompatibility: {error}"
         );
     }
 }
@@ -253,7 +250,7 @@ fn test_streaming_checkpoint_serialization() {
         json_str.contains("1024"),
         "JSON should contain bytes processed"
     );
-    assert!(json_str.contains("5"), "JSON should contain chunk number");
+    assert!(json_str.contains('5'), "JSON should contain chunk number");
 
     // Test deserialization from JSON
     let deserialized: StreamingCheckpoint =
@@ -323,14 +320,13 @@ fn test_chunk_strategy_line_default() {
     // Collect all lines across chunks and verify the full file is covered
     let total_lines_in_chunks: usize = chunks
         .iter()
-        .map(|c| c["lines"].as_array().map(|a| a.len()).unwrap_or(0))
+        .map(|c| c["lines"].as_array().map_or(0, std::vec::Vec::len))
         .sum();
 
     let file_total_lines = content.lines().count();
     assert_eq!(
         total_lines_in_chunks, file_total_lines,
-        "All file lines should appear across chunks: expected {}, got {}",
-        file_total_lines, total_lines_in_chunks
+        "All file lines should appear across chunks: expected {file_total_lines}, got {total_lines_in_chunks}"
     );
 }
 
@@ -369,7 +365,7 @@ fn test_chunk_strategy_semantic() {
     // to avoid splitting in the middle of a declaration
     let any_extended = chunks
         .iter()
-        .any(|c| c["lines"].as_array().map(|a| a.len() > 5).unwrap_or(false));
+        .any(|c| c["lines"].as_array().is_some_and(|a| a.len() > 5));
     assert!(
         any_extended,
         "At least one semantic chunk should extend beyond the nominal chunk size of 5"
@@ -378,21 +374,20 @@ fn test_chunk_strategy_semantic() {
     // All file lines should still be covered
     let total_lines_in_chunks: usize = chunks
         .iter()
-        .map(|c| c["lines"].as_array().map(|a| a.len()).unwrap_or(0))
+        .map(|c| c["lines"].as_array().map_or(0, std::vec::Vec::len))
         .sum();
 
     let file_total_lines = content.lines().count();
     assert_eq!(
         total_lines_in_chunks, file_total_lines,
-        "All file lines should appear across semantic chunks: expected {}, got {}",
-        file_total_lines, total_lines_in_chunks
+        "All file lines should appear across semantic chunks: expected {file_total_lines}, got {total_lines_in_chunks}"
     );
 }
 
 #[test]
 fn test_chunk_strategy_unsupported_language_falls_back() {
     // Plain text — no AST support, should fall back to line-based chunking
-    let lines: Vec<String> = (1..=20).map(|i| format!("plain text line {}", i)).collect();
+    let lines: Vec<String> = (1..=20).map(|i| format!("plain text line {i}")).collect();
     let content = lines.join("\n") + "\n";
     let file = create_streaming_test_file(&content, ".txt");
     let path = file.path().to_str().unwrap();
@@ -428,13 +423,12 @@ fn test_chunk_strategy_unsupported_language_falls_back() {
     // All lines should be covered
     let total_lines_in_chunks: usize = chunks
         .iter()
-        .map(|c| c["lines"].as_array().map(|a| a.len()).unwrap_or(0))
+        .map(|c| c["lines"].as_array().map_or(0, std::vec::Vec::len))
         .sum();
 
     let file_total_lines = lines.len();
     assert_eq!(
         total_lines_in_chunks, file_total_lines,
-        "All text lines should appear across fallback chunks: expected {}, got {}",
-        file_total_lines, total_lines_in_chunks
+        "All text lines should appear across fallback chunks: expected {file_total_lines}, got {total_lines_in_chunks}"
     );
 }


### PR DESCRIPTION
## Summary

`actions-rust-lang/setup-rust-toolchain` sets `RUSTFLAGS=-D warnings` automatically, which turns clippy warnings into errors for all targets. This PR fixes the remaining warnings exposed by `RUSTFLAGS=-D warnings cargo clippy --all-targets --all-features`:

- **tests/**: `uninlined_format_args`, `needless_raw_string_hashes`, `redundant_clone`
- **benches/performance.rs**: `unreadable_literal` (`100000` → `100_000`)
- **examples/theme-showcase.rs**: `cast_possible_truncation`, `unnecessary_wraps`, unused `io` import

## Test plan

- [x] `RUSTFLAGS="-D warnings" cargo clippy --all-targets -- -W clippy::pedantic -W clippy::nursery -W clippy::cargo` — no errors
- [x] `cargo test` — 366 passed, 0 failed
- [ ] Code Quality & Security workflow passes on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Resolve Clippy warnings across tests, benchmarks, and example code to allow building with RUSTFLAGS="-D warnings".

Bug Fixes:
- Adjust tests, benchmarks, and example formatting and iteration patterns to satisfy Clippy lints such as formatting args, literal readability, unused results, and redundant clones when compiling all targets with warnings treated as errors.

Enhancements:
- Mark Config::new in the theme-showcase example as #[must_use] to encourage correct usage.