### PR TITLE
fix(ci): grant missing permissions to health-check and release workflows

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   health-check:
     uses: docdyhr/.github/.github/workflows/rust-health-check.yml@v1

--- a/.github/workflows/release-consolidated.yml
+++ b/.github/workflows/release-consolidated.yml
@@ -13,7 +13,9 @@ on:
         required: true
 
 permissions:
-  contents: read
+  contents: write
+  attestations: write
+  id-token: write
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

- **`health-check.yml`**: adds `permissions: contents: read` + `issues: write` so the callee (`rust-health-check.yml@v1`) can create GitHub issues when it finds problems. Without this block the workflow startup_failed every Wednesday because the repo's default token permission is `read` and `issues: write` couldn't be allocated.

- **`release-consolidated.yml`**: expands `permissions: contents: read` → `contents: write` + `attestations: write` + `id-token: write` to fix two problems:
  1. `tag-after-merge` inline job declared `permissions: contents: write` at job level, which exceeded the workflow-level `contents: read` — GitHub rejects this at startup.
  2. The `rust-release.yml@v1` callee needs `attestations: write` and `id-token: write` to attest artifacts and publish to crates.io via OIDC.

Both manifested as `startup_failure` (no logs, "workflow file issue" message) because GitHub validates permission constraints before any job runs.

## Root cause

GitHub requires job-level and callee-declared permissions to not exceed the calling workflow's top-level permissions. The repo default workflow permission is `read`, so any callee or inline job needing elevated permissions must have those explicitly granted in the caller's `permissions` block.

## Test plan

- [ ] Merge this PR — the Release Management workflow should complete (with all jobs skipped, since no tag is pushed) instead of startup_failing
- [ ] Confirm next Wednesday's health-check run succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust GitHub Actions workflow permissions to align with called workflows and job-level requirements, preventing startup failures.

CI:
- Grant explicit contents and issues permissions to the health-check workflow so the shared rust health-check workflow can create issues.
- Expand release workflow permissions (contents, attestations, id-token) to satisfy job-level and called workflow requirements and avoid permission-related startup failures.