### PR TITLE
fix(security): pin reusable workflow SHAs and scope token permissions

### DIFF
--- a/.github/workflows/ci-optimized.yml
+++ b/.github/workflows/ci-optimized.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: docdyhr/.github/.github/workflows/rust-ci.yml@v1
+    uses: docdyhr/.github/.github/workflows/rust-ci.yml@6cd3461708816bc6918c0efebd720d1fee435be0 # v1
     with:
       binary-name: batless
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,10 +3,7 @@
 
 name: CodeQL Analysis
 
-permissions:
-  contents: read
-  security-events: write
-  actions: read
+permissions: read-all
 
 on:
   push:
@@ -19,7 +16,11 @@ on:
 
 jobs:
   codeql:
-    uses: docdyhr/.github/.github/workflows/codeql.yml@v1
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    uses: docdyhr/.github/.github/workflows/codeql.yml@6cd3461708816bc6918c0efebd720d1fee435be0 # v1
     with:
       languages: '["rust"]'
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/cross-platform-validation.yml
+++ b/.github/workflows/cross-platform-validation.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   cross-platform:
-    uses: docdyhr/.github/.github/workflows/rust-cross-platform.yml@v1
+    uses: docdyhr/.github/.github/workflows/rust-cross-platform.yml@6cd3461708816bc6918c0efebd720d1fee435be0 # v1
     with:
       binary-name: batless
       test-type: ${{ inputs.test_type || 'full' }}

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   health-check:
-    uses: docdyhr/.github/.github/workflows/rust-health-check.yml@v1
+    uses: docdyhr/.github/.github/workflows/rust-health-check.yml@6cd3461708816bc6918c0efebd720d1fee435be0 # v1
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/performance-consolidated.yml
+++ b/.github/workflows/performance-consolidated.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   benchmark:
-    uses: docdyhr/.github/.github/workflows/rust-benchmark.yml@v1
+    uses: docdyhr/.github/.github/workflows/rust-benchmark.yml@6cd3461708816bc6918c0efebd720d1fee435be0 # v1
     with:
       binary-name: batless
       benchmark-script: scripts/benchmark.sh

--- a/.github/workflows/quality-consolidated.yml
+++ b/.github/workflows/quality-consolidated.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   quality:
-    uses: docdyhr/.github/.github/workflows/rust-quality.yml@v1
+    uses: docdyhr/.github/.github/workflows/rust-quality.yml@6cd3461708816bc6918c0efebd720d1fee435be0 # v1
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/release-consolidated.yml
+++ b/.github/workflows/release-consolidated.yml
@@ -12,14 +12,15 @@ on:
         description: "Tag to release (e.g., v1.0.0)"
         required: true
 
-permissions:
-  contents: write
-  attestations: write
-  id-token: write
+permissions: read-all
 
 jobs:
   release:
-    uses: docdyhr/.github/.github/workflows/rust-release.yml@v1
+    permissions:
+      contents: write
+      attestations: write
+      id-token: write
+    uses: docdyhr/.github/.github/workflows/rust-release.yml@6cd3461708816bc6918c0efebd720d1fee435be0 # v1
     with:
       binary-name: batless
     secrets: inherit # pragma: allowlist secret
@@ -29,6 +30,8 @@ jobs:
     name: Update Homebrew Tap
     needs: release
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
     uses: ./.github/workflows/update-homebrew.yml
     with:
       tag: ${{ github.ref_name }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   security:
-    uses: docdyhr/.github/.github/workflows/rust-security.yml@v1
+    uses: docdyhr/.github/.github/workflows/rust-security.yml@6cd3461708816bc6918c0efebd720d1fee435be0 # v1
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/test-consolidated.yml
+++ b/.github/workflows/test-consolidated.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   test-comprehensive:
-    uses: docdyhr/.github/.github/workflows/rust-test-comprehensive.yml@v1
+    uses: docdyhr/.github/.github/workflows/rust-test-comprehensive.yml@6cd3461708816bc6918c0efebd720d1fee435be0 # v1
     with:
       msrv: "1.85.0"
     secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
## Summary

- **PinnedDependencies (×9):** Pin all `docdyhr/.github` reusable workflow `uses:` references from the mutable `@v1` tag to the immutable commit SHA `6cd3461708816bc6918c0efebd720d1fee435be0` with `# v1` comment
- **TokenPermissions (×2 top-level):** Change top-level `permissions` to `read-all` in `codeql.yml` and `release-consolidated.yml`; move write grants (`security-events: write`, `contents/attestations/id-token: write`) to the respective job-level blocks; add `permissions: contents: read` to the `update-homebrew` caller job

Addresses 12 of the 17 open OSSF Scorecard code-scanning alerts. The remaining 5 repo-level alerts (Branch-Protection, Code-Review, CI-Tests, CII-Best-Practices, SAST) require GitHub repository settings changes or external registration.

## Test plan

- [ ] CI passes on this PR (ci-optimized workflow uses the pinned SHA and runs normally)
- [ ] On next Monday Scorecard run, PinnedDependencies and TokenPermissions alerts should close
- [ ] Release workflow still works when a tag is pushed (job-level permissions preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Scope GitHub Actions token permissions and pin reusable workflow references to a specific commit for improved supply-chain security.

Enhancements:
- Move write-level GitHub token permissions from workflow-level to job-level blocks in release and CodeQL workflows, using read-all at the top level.
- Restrict the update-homebrew job to read-only contents permissions.
- Pin all reusable workflow uses of docdyhr/.github from the floating v1 tag to a specific immutable commit SHA.